### PR TITLE
1 architecture setup compilation unit implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.17)
+project(zappy LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED true)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED true)
+
+add_compile_options(
+    "-Wall" "-Wextra" "-Werror" "-pedantic" "-Wpointer-arith" "-fpic"
+)
+
+option(TESTING OFF)
+if (TESTING)
+    add_compile_options("--coverage" "-fprofile-arcs" "-ftest-coverage")
+    add_link_options("--coverage" "-fprofile-arcs" "-ftest-coverage")
+    add_subdirectory(tests)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(zappy_ai)
+add_subdirectory(zappy_gui)
+add_subdirectory(zappy_server)

--- a/src/zappy_ai/CMakeLists.txt
+++ b/src/zappy_ai/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (INCLUDE_ROOT ${PROJECT_SOURCE_DIR}/src/zappy_ai)
+set (SRC_ROOT ${PROJECT_SOURCE_DIR}/src/zappy_ai)

--- a/src/zappy_gui/CMakeLists.txt
+++ b/src/zappy_gui/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (INCLUDE_ROOT ${PROJECT_SOURCE_DIR}/zappy_gui)
+set (SRC_DIR ${PROJECT_SOURCE_DIR}/zappy_gui)

--- a/src/zappy_server/CMakeLists.txt
+++ b/src/zappy_server/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (INCLUDE_ROOT ${PROJECT_SOURCE_DIR}/zappy_server)
+set (SRC_ROOT ${PROJECT_SOURCE_DIR}/zappy_server)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(unit_tests)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+set (INCLUDE_ROOT ${PROJECT_SOURCE_DIR}/tests/unit_tests)
+set (SRC_ROOT ${PROJECT_SOURCE_DIR}/tests/unit_tests)
+
+function (create_test)
+    set (test_name TEST_NAME)
+    set (test_src TEST_SRC TEST_DEPS)
+    cmake_parse_arguments(create_test "" "${test_name}" "${test_src}" ${ARGN})
+
+    if (NOT DEFINED create_test_TEST_NAME)
+        message (FATAL_ERROR "create_test: TEST_NAME not defined")
+    endif()
+    if (NOT DEFINED create_test_TEST_SRC)
+        message (FATAL_ERROR "create_test: TEST_SRC not defined")
+    endif()
+
+    set (SRC "${create_test_TEST_SRC}")
+    set (TEST_NAME "${create_test_TEST_NAME}")
+    set (TEST_DEPS "${create_test_TEST_DEPS}")
+    add_executable(${TEST_NAME} ${SRC})
+    target_link_libraries(${TEST_NAME} ${TEST_DEPS} criterion)
+    add_test(${TEST_NAME} ${TEST_NAME})
+endfunction()

--- a/tests/unit_tests/template/CMakeLists.txt
+++ b/tests/unit_tests/template/CMakeLists.txt
@@ -1,0 +1,13 @@
+set (INCLUDE_ROOT ${PROJECT_SOURCE_DIR}/path/to/tests/src)
+set (SRC_ROOT ${PROJECT_SOURCE_DIR}/path/to/tests/src)
+
+set(TEST_SRC_ROOT
+    ${SRC_ROOT}
+)
+
+create_test(
+    NAME TEST_NAME
+    TEST_SRC TEST_SRC_ROOT
+    TEST_DEPS Any dependencies required by the test (such as archive created by cmake etc...)
+    # Note the test is automatically linked to the testing framework and added to the test suite
+)


### PR DESCRIPTION
This pull request adds the base compilation architecture:

- Adds the  `src` and `tests` as a subdirectory inside the root `CMakeLists.txt` 
- Adds every part of the project inside subdirectory inside the `src` subfolder with their `CMakeLists.txt`


Close #1 