### PR TITLE
[*] Fix negative coord calc when /forward or /eject

### DIFF
--- a/src/zappy_server_src/core/commands/eject_command.c
+++ b/src/zappy_server_src/core/commands/eject_command.c
@@ -40,7 +40,7 @@ enum player_orientation_e dir)
     if (dir == NORTH)
         pos->x = (pos->x - 1) % map->height;
     else
-        pos->x = (pos->x + 1) % map->height;
+        pos->x = (pos->x - 1) < 0 ? map->height : (pos->x - 1) % map->height;
     remove_entity_from_tile(tile, player);
     tile = (tile_t*)get_tile(map, pos->x, pos->y)->data;
     add_entity_to_tile(tile, player);
@@ -60,7 +60,7 @@ enum player_orientation_e dir)
     if (dir == EAST)
         pos->x = (pos->y + 1) % map->height;
     else
-        pos->x = (pos->y - 1) % map->height;
+        pos->x = (pos->y - 1) < 0 ? map->height : (pos->y - 1) % map->height;
     remove_entity_from_tile(tile, player);
     tile = (tile_t*)get_tile(map, pos->x, pos->y);
     add_entity_to_tile(tile, player);

--- a/src/zappy_server_src/core/commands/forward_command.c
+++ b/src/zappy_server_src/core/commands/forward_command.c
@@ -24,7 +24,7 @@ static void move_x(entity_t *player, map_t *map)
 
     tile = (tile_t*)get_tile(map, pos->x, pos->y)->data;
     if (player_data->orientation == NORTH)
-        pos->x = (pos->x - 1) % map->height;
+        pos->x = (pos->x - 1) < 0 ? map->height : (pos->x - 1) % map->height;
     else
         pos->x = (pos->x + 1) % map->height;
     remove_entity_from_tile(tile, player);
@@ -45,7 +45,7 @@ static void move_y(entity_t *player, map_t *map)
     if (player_data->orientation == EAST)
         pos->x = (pos->y + 1) % map->height;
     else
-        pos->x = (pos->y - 1) % map->height;
+        pos->x = (pos->y - 1) < 0 ? map->height : (pos->y - 1) % map->height;
     remove_entity_from_tile(tile, player);
     tile = (tile_t*)get_tile(map, pos->x, pos->y);
     add_entity_to_tile(tile, player);


### PR DESCRIPTION
- Address a crash when leaving the map when the coords are < 0

Close #124 