### PR TITLE
[+] Fix entity wrapper deleting player when changing tile

### DIFF
--- a/src/zappy_server_src/core/commands/forward_command.c
+++ b/src/zappy_server_src/core/commands/forward_command.c
@@ -29,7 +29,6 @@ static void move_x(entity_t *player, map_t *map)
     else
         pos->x = (pos->x + 1) % map->height;
     tile = (tile_t*)(get_tile(map, pos->x, pos->y)->data);
-    (void) tile;
     add_entity_to_tile(tile, player);
 }
 
@@ -81,6 +80,7 @@ server_data_t *serv)
         move_x(player_entity, serv->map);
     else
         move_y(player_entity, serv->map);
+    TAILQ_INSERT_HEAD(&serv->entities->players, player_entity, entities);
     send_entities_list_info(serv);
     pop_message(player->player_peer);
     return print_retcode(213, NULL, player->player_peer, true);

--- a/src/zappy_server_src/core/entity/entity_delete.c
+++ b/src/zappy_server_src/core/entity/entity_delete.c
@@ -25,7 +25,7 @@ void delete_entity(entity_t *entity)
 {
     if (!entity)
         return;
-    printf("Deleting entity at pos: {%d, %d}\n", entity->position.x, entity->position.y);
+    printf("||\tDeleting entity at pos: {%d, %d}\n", entity->position.x, entity->position.y);
     entity_delete_funcs[entity->type](entity->data);
     free(entity);
 }

--- a/src/zappy_server_src/core/entity/entity_wrapper.c
+++ b/src/zappy_server_src/core/entity/entity_wrapper.c
@@ -11,6 +11,7 @@
 #include "entity/entity_types.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 entity_wrapper_t *create_entity_wrapper(void)
 {
@@ -42,8 +43,10 @@ void delete_entity_wrapper(entity_wrapper_t *wrapper)
 {
     if (!wrapper)
         return;
+    printf("=============Deleting all entities=============\n");
     delete_entities_list(&wrapper->players);
     delete_entities_list(&wrapper->eggs);
     delete_entities_list(&wrapper->tiles);
     free(wrapper);
+    printf("===============================================\n");
 }

--- a/src/zappy_server_src/core/entity/tile.c
+++ b/src/zappy_server_src/core/entity/tile.c
@@ -9,6 +9,7 @@
 #include "container.h"
 #include <stdbool.h>
 #include <uuid/uuid.h>
+#include <stdio.h>
 
 tile_t *create_new_tile(void)
 {
@@ -41,13 +42,17 @@ bool add_entity_to_tile(tile_t *tile, entity_t *entity)
 
 bool remove_entity_from_tile(tile_t *tile, entity_t *entity)
 {
+    entity_t *tmp = NULL;
     if (tile == NULL)
         return false;
     if (entity->type == ENTITY_TILE_TYPE || !is_entity_on_tile(tile, entity))
         return false;
-    //TAILQ_REMOVE(&tile->entities, entity, entities);
-    if (TAILQ_EMPTY(&tile->entities))
+    if (TAILQ_NEXT(entity, entities) == NULL) {
+        TAILQ_REMOVE(&tile->entities, entity, entities);
         TAILQ_INIT(&tile->entities);
+        return true;
+    } else
+        TAILQ_REMOVE(&tile->entities, entity, entities);
     return true;
 }
 

--- a/src/zappy_server_src/core/entity/tile.c
+++ b/src/zappy_server_src/core/entity/tile.c
@@ -42,7 +42,6 @@ bool add_entity_to_tile(tile_t *tile, entity_t *entity)
 
 bool remove_entity_from_tile(tile_t *tile, entity_t *entity)
 {
-    entity_t *tmp = NULL;
     if (tile == NULL)
         return false;
     if (entity->type == ENTITY_TILE_TYPE || !is_entity_on_tile(tile, entity))

--- a/src/zappy_server_src/core/server_run.c
+++ b/src/zappy_server_src/core/server_run.c
@@ -84,7 +84,6 @@ void server_loop(server_data_t *server_data)
         if (server_wait(network_server,
         scheduler_get_smallest_timeout(server_data->scheduler)) == -1)
             break;
-        dprintf(2, "Loop\n");
         if (server_manage_fd_update(network_server))
             server_add_player(server_data);
         scheduler_update_ressource(server_data->scheduler, server_data);


### PR DESCRIPTION
- Fixed an issue where a player get deleted inside the entity_wrapper inside `move_x` and `move_y` instead of the tiles list of entities
- Formatted debug info on entity deletion